### PR TITLE
doc/linux/tiering/damon: add basic references

### DIFF
--- a/doc/linux/tiering/damon.rst
+++ b/doc/linux/tiering/damon.rst
@@ -3,7 +3,15 @@
 Data Access MONitor
 ===================
 
-todo
+to be updated
+
+References
+----------
+
+- `Self-tuned Memory Tiering RFC prototype and its evaluation <https://lore.kernel.org/all/20250320053937.57734-1-sj@kernel.org/>`_
+- `SK Hynix HMSDK Capacity Expansion <https://github.com/skhynix/hmsdk/wiki/Capacity-Expansion>`_
+- `kernel documentation <https://origin.kernel.org/doc/html/latest/mm/damon/>`_
+- `project website <https://damonitor.github.io/>`_
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
Put basic references for the topic.  More content updates are needed.